### PR TITLE
Add & collection attachment command

### DIFF
--- a/src/lib/components/chat/MessageInput/Commands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands.svelte
@@ -32,8 +32,10 @@
 	let command = '';
 	$: command = prompt?.split('\n').pop()?.split(' ')?.pop() ?? '';
 
-	let show = false;
-	$: show = ['/', '#', '@'].includes(command?.charAt(0)) || '\\#' === command.slice(0, 2);
+        let show = false;
+        $: show = ['/', '#', '@', '&'].includes(command?.charAt(0)) ||
+                '\\#' === command.slice(0, 2) ||
+                '\\&' === command.slice(0, 2);
 
 	$: if (show) {
 		init();
@@ -57,18 +59,18 @@
 	{#if !loading}
 		{#if command?.charAt(0) === '/'}
 			<Prompts bind:this={commandElement} bind:prompt bind:files {command} />
-		{:else if (command?.charAt(0) === '#' && command.startsWith('#') && !command.includes('# ')) || ('\\#' === command.slice(0, 2) && command.startsWith('#') && !command.includes('# '))}
-			<Knowledge
-				bind:this={commandElement}
-				bind:prompt
-				command={command.includes('\\#') ? command.slice(2) : command}
-				on:youtube={(e) => {
-					console.log(e);
-					dispatch('upload', {
-						type: 'youtube',
-						data: e.detail
-					});
-				}}
+                {:else if (command?.charAt(0) === '#' && command.startsWith('#') && !command.includes('# ')) || ('\\#' === command.slice(0, 2) && command.startsWith('#') && !command.includes('# '))}
+                        <Knowledge
+                                bind:this={commandElement}
+                                bind:prompt
+                                command={command.includes('\\#') ? command.slice(2) : command}
+                                on:youtube={(e) => {
+                                        console.log(e);
+                                        dispatch('upload', {
+                                                type: 'youtube',
+                                                data: e.detail
+                                        });
+                                }}
 				on:url={(e) => {
 					console.log(e);
 					dispatch('upload', {
@@ -91,9 +93,32 @@
 					];
 
 					dispatch('select');
-				}}
-			/>
-		{:else if command?.charAt(0) === '@'}
+                                }}
+                        />
+                {:else if (command?.charAt(0) === '&' && command.startsWith('&') && !command.includes('& ')) || ('\\&' === command.slice(0, 2) && command.startsWith('&') && !command.includes('& '))}
+                        <Knowledge
+                                bind:this={commandElement}
+                                bind:prompt
+                                command={command.includes('\\&') ? command.slice(2) : command}
+                                collectionsOnly={true}
+                                on:select={(e) => {
+                                        console.log(e);
+                                        if (files.find((f) => f.id === e.detail.id)) {
+                                                return;
+                                        }
+
+                                        files = [
+                                                ...files,
+                                                {
+                                                        ...e.detail,
+                                                        status: 'processed'
+                                                }
+                                        ];
+
+                                        dispatch('select');
+                                }}
+                        />
+                {:else if command?.charAt(0) === '@'}
 			<Models
 				bind:this={commandElement}
 				{command}

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -12,8 +12,9 @@
 
 	const i18n = getContext('i18n');
 
-	export let prompt = '';
-	export let command = '';
+        export let prompt = '';
+        export let command = '';
+        export let collectionsOnly: boolean = false;
 
 	const dispatch = createEventDispatcher();
 	let selectedIdx = 0;
@@ -141,14 +142,18 @@
 					]
 				: [];
 
-		items = [...collections, ...collection_files, ...legacy_collections, ...legacy_documents].map(
-			(item) => {
-				return {
-					...item,
-					...(item?.legacy || item?.meta?.legacy || item?.meta?.document ? { legacy: true } : {})
-				};
-			}
-		);
+                items = [...collections, ...collection_files, ...legacy_collections, ...legacy_documents].map(
+                        (item) => {
+                                return {
+                                        ...item,
+                                        ...(item?.legacy || item?.meta?.legacy || item?.meta?.document ? { legacy: true } : {})
+                                };
+                        }
+                );
+
+                if (collectionsOnly) {
+                        items = items.filter((item) => item.type === 'collection');
+                }
 
 		fuse = new Fuse(items, {
 			keys: ['name', 'description']

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -1332,7 +1332,7 @@
 	"URL": "",
 	"URL Mode": "",
 	"Usage": "",
-	"Use '#' in the prompt input to load and include your knowledge.": "",
+        "Use '#' in the prompt input to load and include your knowledge.": "Use '#' or '&' in the prompt input to load and include your knowledge.",
 	"Use Gravatar": "",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1332,7 +1332,7 @@
 	"URL": "",
 	"URL Mode": "",
 	"Usage": "",
-	"Use '#' in the prompt input to load and include your knowledge.": "",
+        "Use '#' in the prompt input to load and include your knowledge.": "Use '#' or '&' in the prompt input to load and include your knowledge.",
 	"Use Gravatar": "",
 	"Use groups to group your users and assign permissions.": "",
 	"Use Initials": "",


### PR DESCRIPTION
## Summary
- extend command trigger detection to include `&`
- support `&` as collection-only attachment in MessageInput
- expose `collectionsOnly` option for knowledge command list
- update English translations mentioning `&`

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad95e4dc8832cb9c615b7a8db7829