### PR TITLE
Add '&' shortcut for knowledge bases

### DIFF
--- a/src/lib/components/chat/MessageInput/Commands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands.svelte
@@ -32,8 +32,10 @@
 	let command = '';
 	$: command = prompt?.split('\n').pop()?.split(' ')?.pop() ?? '';
 
-	let show = false;
-	$: show = ['/', '#', '@'].includes(command?.charAt(0)) || '\\#' === command.slice(0, 2);
+        let show = false;
+        $: show = ['/', '#', '@', '&'].includes(command?.charAt(0)) ||
+                '\\#' === command.slice(0, 2) ||
+                '\\&' === command.slice(0, 2);
 
 	$: if (show) {
 		init();
@@ -55,14 +57,14 @@
 
 {#if show}
 	{#if !loading}
-		{#if command?.charAt(0) === '/'}
-			<Prompts bind:this={commandElement} bind:prompt bind:files {command} />
-		{:else if (command?.charAt(0) === '#' && command.startsWith('#') && !command.includes('# ')) || ('\\#' === command.slice(0, 2) && command.startsWith('#') && !command.includes('# '))}
-			<Knowledge
-				bind:this={commandElement}
-				bind:prompt
-				command={command.includes('\\#') ? command.slice(2) : command}
-				on:youtube={(e) => {
+                {#if command?.charAt(0) === '/'}
+                        <Prompts bind:this={commandElement} bind:prompt bind:files {command} />
+                {:else if (command?.charAt(0) === '#' && command.startsWith('#') && !command.includes('# ')) || ('\\#' === command.slice(0, 2) && command.startsWith('#') && !command.includes('# '))}
+                        <Knowledge
+                                bind:this={commandElement}
+                                bind:prompt
+                                command={command.includes('\\#') ? command.slice(2) : command}
+                                on:youtube={(e) => {
 					console.log(e);
 					dispatch('upload', {
 						type: 'youtube',
@@ -90,13 +92,35 @@
 						}
 					];
 
-					dispatch('select');
-				}}
-			/>
-		{:else if command?.charAt(0) === '@'}
-			<Models
-				bind:this={commandElement}
-				{command}
+                                        dispatch('select');
+                                }}
+                        />
+                {:else if (command?.charAt(0) === '&' && command.startsWith('&') && !command.includes('& ')) || ('\\&' === command.slice(0, 2) && command.startsWith('&') && !command.includes('& '))}
+                        <Knowledge
+                                bind:this={commandElement}
+                                bind:prompt
+                                command={command.includes('\\&') ? command.slice(2) : command}
+                                collectionsOnly={true}
+                                on:select={(e) => {
+                                        if (files.find((f) => f.id === e.detail.id)) {
+                                                return;
+                                        }
+
+                                        files = [
+                                                ...files,
+                                                {
+                                                        ...e.detail,
+                                                        status: 'processed'
+                                                }
+                                        ];
+
+                                        dispatch('select');
+                                }}
+                        />
+                {:else if command?.charAt(0) === '@'}
+                        <Models
+                                bind:this={commandElement}
+                                {command}
 				on:select={(e) => {
 					prompt = removeLastWordFromString(prompt, command);
 

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -12,8 +12,9 @@
 
 	const i18n = getContext('i18n');
 
-	export let prompt = '';
-	export let command = '';
+        export let prompt = '';
+        export let command = '';
+        export let collectionsOnly = false;
 
 	const dispatch = createEventDispatcher();
 	let selectedIdx = 0;
@@ -141,12 +142,17 @@
 					]
 				: [];
 
-		items = [...collections, ...collection_files, ...legacy_collections, ...legacy_documents].map(
-			(item) => {
-				return {
-					...item,
-					...(item?.legacy || item?.meta?.legacy || item?.meta?.document ? { legacy: true } : {})
-				};
+                let baseItems = [...collections, ...legacy_collections];
+                if (!collectionsOnly) {
+                        baseItems = [...baseItems, ...collection_files, ...legacy_documents];
+                }
+
+                items = baseItems.map(
+                        (item) => {
+                                return {
+                                        ...item,
+                                        ...(item?.legacy || item?.meta?.legacy || item?.meta?.document ? { legacy: true } : {})
+                                };
 			}
 		);
 
@@ -164,7 +170,7 @@
 	};
 </script>
 
-{#if filteredItems.length > 0 || prompt.split(' ')?.at(0)?.substring(1).startsWith('http')}
+{#if filteredItems.length > 0 || (!collectionsOnly && prompt.split(' ')?.at(0)?.substring(1).startsWith('http'))}
 	<div
 		id="commands-container"
 		class="px-2 mb-2 text-left w-full absolute bottom-0 left-0 right-0 z-10"
@@ -272,11 +278,11 @@
 							</div> -->
 					{/each}
 
-					{#if prompt
-						.split(' ')
-						.some((s) => s.substring(1).startsWith('https://www.youtube.com') || s
-									.substring(1)
-									.startsWith('https://youtu.be'))}
+                                        {#if !collectionsOnly && prompt
+                                                .split(' ')
+                                                .some((s) => s.substring(1).startsWith('https://www.youtube.com') || s
+                                                                        .substring(1)
+                                                                        .startsWith('https://youtu.be'))}
 						<button
 							class="px-3 py-1.5 rounded-xl w-full text-left bg-gray-50 dark:bg-gray-850 dark:text-gray-100 selected-command-option-button"
 							type="button"
@@ -299,7 +305,7 @@
 
 							<div class=" text-xs text-gray-600 line-clamp-1">{$i18n.t('Youtube')}</div>
 						</button>
-					{:else if prompt.split(' ')?.at(0)?.substring(1).startsWith('http')}
+                                        {:else if !collectionsOnly && prompt.split(' ')?.at(0)?.substring(1).startsWith('http')}
 						<button
 							class="px-3 py-1.5 rounded-xl w-full text-left bg-gray-50 dark:bg-gray-850 dark:text-gray-100 selected-command-option-button"
 							type="button"

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -547,10 +547,13 @@ export const removeLastWordFromString = (inputString, wordString) => {
 	// Split the last line into an array of words
 	const words = lastLine.split(' ');
 
-	// Conditional to check for the last word removal
-	if (words.at(-1) === wordString || (wordString === '' && words.at(-1) === '\\#')) {
-		words.pop(); // Remove last word if condition is satisfied
-	}
+        // Conditional to check for the last word removal
+        if (
+                words.at(-1) === wordString ||
+                (wordString === '' && ['\\#', '\\&'].includes(words.at(-1)))
+        ) {
+                words.pop(); // Remove last word if condition is satisfied
+        }
 
 	// Join the remaining words back into a string and handle space correctly
 	let updatedLastLine = words.join(' ');


### PR DESCRIPTION
## Summary
- support `&` prefix to attach collections in conversations
- extend knowledge command to allow collection-only suggestions
- adjust utils for ampersand command handling

## Testing
- `npm run lint` *(fails: eslint, svelte-kit, pylint not found)*
- `npm run test:frontend` *(fails: vitest not found)*
- `pytest` *(fails: ModuleNotFoundError: docker)*

------
https://chatgpt.com/codex/tasks/task_e_686ad95e4dc8832cb9c615b7a8db7829